### PR TITLE
New hierarchy find functions

### DIFF
--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -409,6 +409,114 @@ class Entity extends GraphNode {
     }
 
     /**
+     * Search the entity and all of its descendants for the first script instance of specified type.
+     *
+     * @param {string|Class<ScriptType>} nameOrType - The name or type of {@link ScriptType}.
+     * @returns {ScriptType} A script instance of specified type, if the entity or any of its descendants
+     * has one. Returns undefined otherwise.
+     * @example
+     * // Get the first found "playerController" instance in the hierarchy tree that starts with this entity
+     * var controller = entity.findScript("playerController");
+     */
+    findScript(nameOrType) {
+        const entity = this.findOne(function (node) {
+            return node.c && node.c.script && node.c.script.has(nameOrType);
+        });
+        return entity && entity.c.script.get(nameOrType);
+    }
+
+    /**
+     * Search the entity and all of its descendants for all script instances of specified type.
+     *
+     * @param {string|Class<ScriptType>} nameOrType - The name or type of {@link ScriptType}.
+     * @returns {ScriptType[]} All script instances of specified type in the entity or any of its
+     * descendants. Returns empty array if none found.
+     * @example
+     * // Get all "playerController" instances in the hierarchy tree that starts with this entity
+     * var controllers = entity.findScripts("playerController");
+     */
+    findScripts(nameOrType) {
+        const entities = this.find(function (node) {
+            return node.c && node.c.script && node.c.script.has(nameOrType);
+        });
+        return entities.map(function (entity) {
+            return entity.c.script.get(nameOrType);
+        });
+    }
+
+    /**
+     * Search the entity and all of its ascendants for the first component of specified type.
+     *
+     * @param {string} type - The name of the component type to retrieve.
+     * @returns {Component} A component of specified type, if the entity or any of its ascendants
+     * has one. Returns undefined otherwise.
+     * @example
+     * // Get the first found light component in the ancestor tree that starts with this entity
+     * var light = entity.findComponentInParent("light");
+     */
+    findComponentInParent(type) {
+        const entity = this.findOneInParent(function (node) {
+            return node.c && node.c[type];
+        });
+        return entity && entity.c[type];
+    }
+
+    /**
+     * Search the entity and all of its ascendants for all components of specified type.
+     *
+     * @param {string} type - The name of the component type to retrieve.
+     * @returns {Component[]} All components of specified type in the entity or any of its
+     * ascendants. Returns empty array if none found.
+     * @example
+     * // Get all element components in the ancestor tree that starts with this entity
+     * var elements = entity.findComponentsInParent("element");
+     */
+    findComponentsInParent(type) {
+        const entities = this.findInParent(function (node) {
+            return node.c && node.c[type];
+        });
+        return entities.map(function (entity) {
+            return entity.c[type];
+        });
+    }
+
+    /**
+     * Search the entity and all of its ascendants for the first script instance of specified type.
+     *
+     * @param {string|Class<ScriptType>} nameOrType - The name or type of {@link ScriptType}.
+     * @returns {ScriptType} A script instance of specified type, if the entity or any of its ascendants
+     * has one. Returns undefined otherwise.
+     * @example
+     * // Get the first found "playerController" instance in the ancestor tree that starts with this entity
+     * var controller = entity.findScriptInParent("playerController");
+     */
+    findScriptInParent(nameOrType) {
+        const entity = this.findOneInParent(function (node) {
+            return node.c && node.c.script && node.c.script.has(nameOrType);
+        });
+        return entity && entity.c.script.get(nameOrType);
+    }
+
+    /**
+     * Search the entity and all of its ascendants for all script instances of specified type.
+     *
+     * @param {string|Class<ScriptType>} nameOrType - The name or type of {@link ScriptType}.
+     * @returns {ScriptType[]} All script instances of specified type in the entity or any of its
+     * ascendants. Returns empty array if none found.
+     * @example
+     * // Get all "playerController" instance in the ancestor tree that starts with this entity
+     * var controllers = entity.findScriptsInParent("playerController");
+     */
+    findScriptsInParent(nameOrType) {
+        const entities = this.findInParent(function (node) {
+            return node.c && node.c.script && node.c.script.has(nameOrType);
+        });
+        return entities.map(function (entity) {
+            return entity.c.script.get(nameOrType);
+        });
+    }
+
+    /**
      * Get the GUID value for this Entity.
      *
      * @returns {string} The GUID of the Entity.

--- a/test/framework/entity.test.mjs
+++ b/test/framework/entity.test.mjs
@@ -675,6 +675,112 @@ describe('Entity', function () {
 
     });
 
+    describe('#findComponentInParent', function () {
+
+        it('finds component on single entity', function () {
+            const e = new Entity();
+            e.addComponent('anim');
+            const component = e.findComponentInParent('anim');
+            expect(component).to.be.an.instanceof(AnimComponent);
+        });
+
+        it('returns null when component is not found', function () {
+            const e = new Entity();
+            e.addComponent('anim');
+            const component = e.findComponentInParent('render');
+            expect(component).to.be.null;
+        });
+
+        it('finds component on parent entity', function () {
+            const root = new Entity();
+            const child = new Entity();
+            root.addChild(child);
+            root.addComponent('anim');
+            const component = child.findComponentInParent('anim');
+            expect(component).to.be.an.instanceof(AnimComponent);
+        });
+
+        it('finds component on grandparent entity', function () {
+            const root = new Entity();
+            const child = new Entity();
+            const grandchild = new Entity();
+            root.addChild(child);
+            child.addChild(grandchild);
+            root.addComponent('anim');
+            const component = grandchild.findComponentInParent('anim');
+            expect(component).to.be.an.instanceof(AnimComponent);
+        });
+
+        it('does not find component on child entity', function () {
+            const root = new Entity();
+            const child = new Entity();
+            root.addChild(child);
+            child.addComponent('anim');
+            const component = root.findComponentInParent('anim');
+            expect(component).to.be.null;
+        });
+
+    });
+
+    describe('#findComponentsInParent', function () {
+
+        it('finds components on single entity', function () {
+            const e = new Entity();
+            e.addComponent('anim');
+            const components = e.findComponentsInParent('anim');
+            expect(components).to.be.an('array');
+            expect(components.length).to.equal(1);
+            expect(components[0]).to.be.an.instanceof(AnimComponent);
+        });
+
+        it('returns empty array when no components are found', function () {
+            const e = new Entity();
+            e.addComponent('anim');
+            const components = e.findComponentsInParent('render');
+            expect(components).to.be.an('array');
+            expect(components.length).to.equal(0);
+        });
+
+        it('finds components on parent entity', function () {
+            const root = new Entity();
+            const child = new Entity();
+            root.addChild(child);
+            root.addComponent('anim');
+            const components = child.findComponentsInParent('anim');
+            expect(components).to.be.an('array');
+            expect(components.length).to.equal(1);
+            expect(components[0]).to.be.an.instanceof(AnimComponent);
+        });
+
+        it('finds components on 3 entity hierarchy', function () {
+            const root = new Entity();
+            const child = new Entity();
+            const grandchild = new Entity();
+            root.addChild(child);
+            child.addChild(grandchild);
+            root.addComponent('anim');
+            child.addComponent('anim');
+            grandchild.addComponent('anim');
+            const components = grandchild.findComponentsInParent('anim');
+            expect(components).to.be.an('array');
+            expect(components.length).to.equal(3);
+            expect(components[0]).to.be.an.instanceof(AnimComponent);
+            expect(components[1]).to.be.an.instanceof(AnimComponent);
+            expect(components[2]).to.be.an.instanceof(AnimComponent);
+        });
+
+        it('does not find components on child entity', function () {
+            const root = new Entity();
+            const child = new Entity();
+            root.addChild(child);
+            child.addComponent('anim');
+            const components = root.findComponentsInParent('anim');
+            expect(components).to.be.an('array');
+            expect(components.length).to.equal(0);
+        });
+
+    });
+
     describe('#removeComponent', function () {
 
         it('removes a component from the entity', function () {

--- a/test/framework/entity.test.mjs
+++ b/test/framework/entity.test.mjs
@@ -675,6 +675,147 @@ describe('Entity', function () {
 
     });
 
+    describe('#findScript', function () {
+
+        it('finds script on single entity', function () {
+			const MyScript = createScript('myScript');
+            const e = new Entity();
+            e.addComponent('script');
+            e.script.create('myScript');
+            const script = e.findScript('myScript');
+            expect(script).to.be.an.instanceof(MyScript);
+        });
+
+        it('returns null when script is not found', function () {
+			const MyScript = createScript('myScript');
+            const e = new Entity();
+            e.addComponent('script');
+            const script = e.findScript('myScript');
+            expect(script).to.be.null;
+        });
+
+        it('returns null when script component is not found', function () {
+			const MyScript = createScript('myScript');
+            const e = new Entity();
+            const script = e.findScript('myScript');
+            expect(script).to.be.null;
+        });
+
+        it('finds script on child entity', function () {
+			const MyScript = createScript('myScript');
+            const root = new Entity();
+            const child = new Entity();
+            root.addChild(child);
+            child.addComponent('script');
+            child.script.create('myScript');
+            const script = root.findScript('myScript');
+            expect(script).to.be.an.instanceof(MyScript);
+        });
+
+        it('finds script on grandchild entity', function () {
+			const MyScript = createScript('myScript');
+            const root = new Entity();
+            const child = new Entity();
+            const grandchild = new Entity();
+            root.addChild(child);
+            child.addChild(grandchild);
+            grandchild.addComponent('script');
+            grandchild.script.create('myScript');
+            const script = root.findScript('myScript');
+            expect(script).to.be.an.instanceof(MyScript);
+        });
+
+        it('does not find script on parent entity', function () {
+			const MyScript = createScript('myScript');
+            const root = new Entity();
+            const child = new Entity();
+            root.addChild(child);
+            root.addComponent('script');
+            root.script.create('myScript');
+            const script = child.findScript('myScript');
+            expect(script).to.be.null;
+        });
+
+    });
+
+    describe('#findScripts', function () {
+
+        it('finds scripts on single entity', function () {
+			const MyScript = createScript('myScript');
+            const e = new Entity();
+            e.addComponent('script');
+            e.script.create('myScript');
+            const scripts = e.findScripts('myScript');
+            expect(scripts).to.be.an('array');
+            expect(scripts.length).to.equal(1);
+            expect(scripts[0]).to.be.an.instanceof(MyScript);
+        });
+
+        it('returns empty array when no scripts are found', function () {
+			const MyScript = createScript('myScript');
+            const e = new Entity();
+            e.addComponent('script');
+            const scripts = e.findScripts('myScript');
+            expect(scripts).to.be.an('array');
+            expect(scripts.length).to.equal(0);
+        });
+
+        it('returns empty array when no script component are found', function () {
+			const MyScript = createScript('myScript');
+            const e = new Entity();
+            const scripts = e.findScripts('myScript');
+            expect(scripts).to.be.an('array');
+            expect(scripts.length).to.equal(0);
+        });
+
+        it('finds scripts on child entity', function () {
+			const MyScript = createScript('myScript');
+            const root = new Entity();
+            const child = new Entity();
+            root.addChild(child);
+            child.addComponent('script');
+            child.script.create('myScript');
+            const scripts = root.findScripts('myScript');
+            expect(scripts).to.be.an('array');
+            expect(scripts.length).to.equal(1);
+            expect(scripts[0]).to.be.an.instanceof(MyScript);
+        });
+
+        it('finds scripts on 3 entity hierarchy', function () {
+			const MyScript = createScript('myScript');
+            const root = new Entity();
+            const child = new Entity();
+            const grandchild = new Entity();
+            root.addChild(child);
+            child.addChild(grandchild);
+            root.addComponent('script');
+            root.script.create('myScript');
+            child.addComponent('script');
+            child.script.create('myScript');
+            grandchild.addComponent('script');
+            grandchild.script.create('myScript');
+            const scripts = root.findScripts('myScript');
+            expect(scripts).to.be.an('array');
+            expect(scripts.length).to.equal(3);
+            expect(scripts[0]).to.be.an.instanceof(MyScript);
+            expect(scripts[1]).to.be.an.instanceof(MyScript);
+            expect(scripts[2]).to.be.an.instanceof(MyScript);
+        });
+
+        it('does not find scripts on parent entity', function () {
+			const MyScript = createScript('myScript');
+            const root = new Entity();
+            const child = new Entity();
+            root.addChild(child);
+            root.addComponent('script');
+            root.script.create('myScript');
+            const scripts = child.findScripts('myScript');
+            expect(scripts).to.be.an('array');
+            expect(scripts.length).to.equal(0);
+        });
+
+    });
+
     describe('#findComponentInParent', function () {
 
         it('finds component on single entity', function () {
@@ -777,6 +918,147 @@ describe('Entity', function () {
             const components = root.findComponentsInParent('anim');
             expect(components).to.be.an('array');
             expect(components.length).to.equal(0);
+        });
+
+    });
+
+    describe('#findScriptInParent', function () {
+
+        it('finds script on single entity', function () {
+			const MyScript = createScript('myScript');
+            const e = new Entity();
+            e.addComponent('script');
+            e.script.create('myScript');
+            const script = e.findScriptInParent('myScript');
+            expect(script).to.be.an.instanceof(MyScript);
+        });
+
+        it('returns null when script is not found', function () {
+			const MyScript = createScript('myScript');
+            const e = new Entity();
+            e.addComponent('script');
+            const script = e.findScriptInParent('myScript');
+            expect(script).to.be.null;
+        });
+
+        it('returns null when script component is not found', function () {
+			const MyScript = createScript('myScript');
+            const e = new Entity();
+            const script = e.findScriptInParent('myScript');
+            expect(script).to.be.null;
+        });
+
+        it('finds script on parent entity', function () {
+			const MyScript = createScript('myScript');
+            const root = new Entity();
+            const child = new Entity();
+            root.addChild(child);
+            root.addComponent('script');
+            root.script.create('myScript');
+            const script = child.findScriptInParent('myScript');
+            expect(script).to.be.an.instanceof(MyScript);
+        });
+
+        it('finds script on grandparent entity', function () {
+			const MyScript = createScript('myScript');
+            const root = new Entity();
+            const child = new Entity();
+            const grandchild = new Entity();
+            root.addChild(child);
+            child.addChild(grandchild);
+            root.addComponent('script');
+            root.script.create('myScript');
+            const script = grandchild.findScriptInParent('myScript');
+            expect(script).to.be.an.instanceof(MyScript);
+        });
+
+        it('does not find script on child entity', function () {
+			const MyScript = createScript('myScript');
+            const root = new Entity();
+            const child = new Entity();
+            root.addChild(child);
+            child.addComponent('script');
+            child.script.create('myScript');
+            const script = root.findScriptInParent('myScript');
+            expect(script).to.be.null;
+        });
+
+    });
+
+    describe('#findScriptsInParent', function () {
+
+        it('finds scripts on single entity', function () {
+			const MyScript = createScript('myScript');
+            const e = new Entity();
+            e.addComponent('script');
+            e.script.create('myScript');
+            const scripts = e.findScriptsInParent('myScript');
+            expect(scripts).to.be.an('array');
+            expect(scripts.length).to.equal(1);
+            expect(scripts[0]).to.be.an.instanceof(MyScript);
+        });
+
+        it('returns empty array when no scripts are found', function () {
+			const MyScript = createScript('myScript');
+            const e = new Entity();
+            e.addComponent('script');
+            const scripts = e.findScriptsInParent('myScript');
+            expect(scripts).to.be.an('array');
+            expect(scripts.length).to.equal(0);
+        });
+
+        it('returns empty array when no script component are found', function () {
+			const MyScript = createScript('myScript');
+            const e = new Entity();
+            const scripts = e.findScriptsInParent('myScript');
+            expect(scripts).to.be.an('array');
+            expect(scripts.length).to.equal(0);
+        });
+
+        it('finds scripts on parent entity', function () {
+			const MyScript = createScript('myScript');
+            const root = new Entity();
+            const child = new Entity();
+            root.addChild(child);
+            root.addComponent('script');
+            root.script.create('myScript');
+            const scripts = child.findScriptsInParent('myScript');
+            expect(scripts).to.be.an('array');
+            expect(scripts.length).to.equal(1);
+            expect(scripts[0]).to.be.an.instanceof(MyScript);
+        });
+
+        it('finds scripts on 3 entity hierarchy', function () {
+			const MyScript = createScript('myScript');
+            const root = new Entity();
+            const child = new Entity();
+            const grandchild = new Entity();
+            root.addChild(child);
+            child.addChild(grandchild);
+            root.addComponent('script');
+            root.script.create('myScript');
+            child.addComponent('script');
+            child.script.create('myScript');
+            grandchild.addComponent('script');
+            grandchild.script.create('myScript');
+            const scripts = grandchild.findScriptsInParent('myScript');
+            expect(scripts).to.be.an('array');
+            expect(scripts.length).to.equal(3);
+            expect(scripts[0]).to.be.an.instanceof(MyScript);
+            expect(scripts[1]).to.be.an.instanceof(MyScript);
+            expect(scripts[2]).to.be.an.instanceof(MyScript);
+        });
+
+        it('does not find scripts on child entity', function () {
+			const MyScript = createScript('myScript');
+            const root = new Entity();
+            const child = new Entity();
+            root.addChild(child);
+            child.addComponent('script');
+            child.script.create('myScript');
+            const scripts = root.findScriptsInParent('myScript');
+            expect(scripts).to.be.an('array');
+            expect(scripts.length).to.equal(0);
         });
 
     });

--- a/test/scene/graph-node.test.mjs
+++ b/test/scene/graph-node.test.mjs
@@ -413,6 +413,94 @@ describe('GraphNode', function () {
 
     });
 
+    describe('#findInParent()', function () {
+
+        it('finds a node by property', function () {
+            const root = new GraphNode('Parent');
+            const child = new GraphNode('Child');
+            root.addChild(child);
+
+            let res;
+            res = child.findInParent('name', 'Parent');
+            expect(res).to.be.an('array').with.lengthOf(1);
+            expect(res[0]).to.equal(root);
+
+            res = child.findInParent('name', 'Child');
+            expect(res).to.be.an('array').with.lengthOf(1);
+            expect(res[0]).to.equal(child);
+
+            res = child.findInParent('name', 'Not Found');
+            expect(res).to.be.an('array').with.lengthOf(0);
+        });
+
+        it('finds a node by filter function', function () {
+            const root = new GraphNode('Parent');
+            const child = new GraphNode('Child');
+            root.addChild(child);
+
+            let res;
+            res = child.findInParent(function (node) {
+                return node.name === 'Parent';
+            });
+            expect(res).to.be.an('array').with.lengthOf(1);
+            expect(res[0]).to.equal(root);
+
+            res = child.findInParent(function (node) {
+                return node.name === 'Child';
+            });
+            expect(res).to.be.an('array').with.lengthOf(1);
+            expect(res[0]).to.equal(child);
+
+            res = child.findInParent(function (node) {
+                return node.name === 'Not Found';
+            });
+            expect(res).to.be.an('array').with.lengthOf(0);
+        });
+
+    });
+
+    describe('#findOneInParent()', function () {
+
+        it('finds a node by property', function () {
+            const root = new GraphNode('Parent');
+            const child = new GraphNode('Child');
+            root.addChild(child);
+
+            let res;
+            res = child.findOneInParent('name', 'Parent');
+            expect(res).to.equal(root);
+
+            res = child.findOneInParent('name', 'Child');
+            expect(res).to.equal(child);
+
+            res = child.findOneInParent('name', 'Not Found');
+            expect(res).to.be.null;
+        });
+
+        it('finds a node by filter function', function () {
+            const root = new GraphNode('Parent');
+            const child = new GraphNode('Child');
+            root.addChild(child);
+
+            let res;
+            res = child.findOneInParent(function (node) {
+                return node.name === 'Parent';
+            });
+            expect(res).to.equal(root);
+
+            res = child.findOneInParent(function (node) {
+                return node.name === 'Child';
+            });
+            expect(res).to.equal(child);
+
+            res = child.findOneInParent(function (node) {
+                return node.name === 'Not Found';
+            });
+            expect(res).to.be.null;
+        });
+
+    });
+
     describe('#forEach()', function () {
 
         it('iterates over all nodes', function () {


### PR DESCRIPTION
This PR add various functions to find entities, components and script instances either through parents or children. It completes the already existing functions to find through children and can be used the same way.

List of new functions:
- GraphNode.findInParent
- GraphNode.findOneInParent
- Entity.findScript
- Entity.findScripts
- Entity.findComponentInParent
- Entity.findComponentsInParent
- Entity.findScriptInParent
- Entity.findScriptsInParent

I hope I documentated them correctly. I also added unit tests inspired by the existing ones.